### PR TITLE
Add one-liner install script for new project scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,11 @@ This starts uvicorn with auto-reload and the CSS watcher.
 
 ## Using as a Template
 
-Clone and reset history:
-
 ```bash
-git clone git@github.com:nativecampus/base_app.git my_new_app && cd my_new_app && rm -rf .git && git init
+curl -sL https://raw.githubusercontent.com/nativecampus/base_app/main/install.sh | bash -s my_new_app
 ```
 
-Initialise the project (renames everything, installs deps, creates databases, runs migrations, builds CSS):
-
-```bash
-python manage.py init my_new_app
-```
-
-Skip database creation (CI or headless environments):
-
-```bash
-python manage.py init my_new_app --no-db
-```
+This clones the repo, renames everything, installs dependencies, creates databases, runs migrations, builds CSS, and makes an initial commit.
 
 Then add your models in `app/models/`, schemas in `app/schemas/`, services in `app/services/`, routes in `app/routers/`, and generate your first migration with `pipenv run alembic revision --autogenerate -m "initial tables"`.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,10 +10,16 @@
 ## Initial Project Setup (from template)
 
 ```bash
-python manage.py init your_project_name
+curl -sL https://raw.githubusercontent.com/nativecampus/base_app/main/install.sh | bash -s your_project_name
 ```
 
-This renames all references, installs dependencies, creates databases, runs migrations, and builds CSS.
+This clones the repo, renames all references, installs dependencies, creates databases, runs migrations, builds CSS, and makes an initial commit.
+
+To run just the init step separately (e.g. if you already cloned manually):
+
+```bash
+python manage.py init your_project_name
+```
 
 ## Setup
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="nativecampus/base_app"
+
+usage() {
+    echo "Usage: curl -sL https://raw.githubusercontent.com/$REPO/main/install.sh | bash -s <project_name>"
+    echo "  project_name: snake_case (e.g. email_reviewer, brace_scraper)"
+    exit 1
+}
+
+name="${1:-}"
+[ -z "$name" ] && usage
+
+if ! [[ "$name" =~ ^[a-z][a-z0-9_]*$ ]]; then
+    echo "Error: project name must be snake_case (lowercase letters, digits, underscores, starting with a letter)"
+    exit 1
+fi
+
+if [ "$name" = "base_app" ]; then
+    echo "Error: pick a real name, not 'base_app'"
+    exit 1
+fi
+
+if [ -d "$name" ]; then
+    echo "Error: directory '$name' already exists"
+    exit 1
+fi
+
+for cmd in git python3 pipenv npm createdb; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: $cmd is required but not found"
+        exit 1
+    fi
+done
+
+echo "Creating $name..."
+
+git clone --quiet "git@github.com:$REPO.git" "$name"
+cd "$name"
+rm -rf .git .claude .coderabbit.yaml install.sh
+git init --quiet
+
+python3 manage.py init "$name"
+
+git add -A
+git commit --quiet -m "Initial commit from base_app template"
+
+echo ""
+echo "Ready. Next steps:"
+echo "  cd $name"
+echo "  python manage.py dev"


### PR DESCRIPTION
## Summary

- Adds `install.sh` at repo root — validates input, clones, reinits git, runs `python manage.py init`, and makes an initial commit
- Updates README "Using as a Template" section with the curl one-liner
- Updates docs/development.md "Initial Project Setup" section

## Usage

```bash
curl -sL https://raw.githubusercontent.com/nativecampus/base_app/main/install.sh | bash -s my_new_app
```

## Test plan

- [x] Full test suite passes (45/45)
- [ ] Manual: curl the script and scaffold a test project

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined installer script that automates the entire project initialisation process in one command, replacing the previous multi-step manual setup.

* **Documentation**
  * Updated README and development documentation to reflect the new automated installation workflow and include instructions for running individual setup steps independently when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->