### PR TITLE
Fix install.sh repo URL and add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Radar Leisure Tech Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Project template for internal Python web applications.
 ## Create a New Project
 
 ```bash
-curl -sL https://raw.githubusercontent.com/nativecampus/base_app/main/install.sh | bash -s my_new_app
+curl -sL https://raw.githubusercontent.com/nativecampus/base_app_v1/main/install.sh | bash -s my_new_app
 ```
 
 This clones the template, renames everything to your project name, installs dependencies, creates databases, runs migrations, builds CSS, and makes an initial git commit.

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,7 +10,7 @@
 ## Initial Project Setup (from template)
 
 ```bash
-curl -sL https://raw.githubusercontent.com/nativecampus/base_app/main/install.sh | bash -s your_project_name
+curl -sL https://raw.githubusercontent.com/nativecampus/base_app_v1/main/install.sh | bash -s your_project_name
 ```
 
 This clones the repo, renames all references, installs dependencies, creates databases, runs migrations, builds CSS, and makes an initial commit.

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="nativecampus/base_app"
+REPO="nativecampus/base_app_v1"
 
 usage() {
     echo "Usage: curl -sL https://raw.githubusercontent.com/$REPO/main/install.sh | bash -s <project_name>"


### PR DESCRIPTION
## Summary
- Fix `REPO` variable in `install.sh` from `nativecampus/base_app` to `nativecampus/base_app_v1` (was returning 404)
- Update install URLs in README.md and docs/development.md to match
- Add MIT license (Radar Leisure Tech Ltd) for public release

## Test plan
- [ ] `curl -sL https://raw.githubusercontent.com/nativecampus/base_app_v1/main/install.sh | bash -s test_app` works after repo is made public
- [ ] All 51 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added MIT licence documentation with copyright attribution to Radar Leisure Tech Ltd
  * Updated project setup and documentation to reference updated source repository for installation resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->