### PR TITLE
Include test_manage.py in init rename replacements

### DIFF
--- a/scripts/init_project.py
+++ b/scripts/init_project.py
@@ -32,6 +32,7 @@ REPLACEMENTS: list[tuple[str, list[tuple[str, str]]]] = [
     (".github/workflows/ci.yml", [("base_app", "snake")]),
     ("package.json", [("base_app", "snake")]),
     ("manage.py", [("base_app", "snake")]),
+    ("tests/test_manage.py", [("base_app", "snake")]),
 ]
 
 

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -166,7 +166,7 @@ class TestCmdInit:
 
     def test_invalid_name_exits(self):
         with pytest.raises(SystemExit) as exc:
-            args = build_parser().parse_args(["init", "base_app"])
+            args = build_parser().parse_args(["init", "0bad"])
             cmd_init(args)
         assert exc.value.code == 1
 


### PR DESCRIPTION
## Summary

- `tests/test_manage.py` was missing from the `REPLACEMENTS` list in `init_project.py`, so `manage.py init <name>` renamed production code but left test assertions hardcoded to `"base_app"`, causing CI failure
- Added the test file to `REPLACEMENTS` so it gets renamed alongside `manage.py`
- Changed `test_invalid_name_exits` to use `"0bad"` (starts with digit, fails regex) instead of `"base_app"` which would be rewritten by the replacement

## Test plan

- [x] Full test suite passes locally (53 passed)
- [ ] CI passes after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Enhanced the project initialisation scaffolding process to ensure that template variable renaming is applied uniformly and consistently across all automatically generated project files.

**Tests**
* Strengthened project initialisation validation testing to confirm that invalid project names are correctly rejected with proper error exit codes, improving the overall reliability of error handling and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->